### PR TITLE
Change deps from LightGraphs to Graphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,11 @@ authors = ["Chen Zhao"]
 version = "0.2.2"
 
 [deps]
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-LightGraphs = "1"
 julia = "1.2"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/QuantumBFS/Multigraphs.jl/workflows/CI/badge.svg)](https://github.com/QuantumBFS/Multigraphs.jl/actions)
 [![Codecov](https://codecov.io/gh/QuantumBFS/Multigraphs.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/QuantumBFS/Multigraphs.jl)
 
-Multigraphs extension for `LightGraphs.jl`.
+Multigraphs extension for `Graphs.jl`.
 
 ## Installation
 
@@ -25,7 +25,7 @@ pkg> add Multigraphs
 ## Examples
 
 ```julia
-using LightGraphs, Multigraphs
+using Graphs, Multigraphs
 
 # create a undirected multigraph with 3 vertices and 0 multiple edges
 # use DiMultigraph for directed multigraphs
@@ -53,7 +53,7 @@ julia> mes = [me for me in edges(mg)]
 Multiple edge 1 => 2 with multiplicity 2
 Multiple edge 2 => 3 with multiplicity 1
 
-# here e is a LightGraphs.SimpleEdge
+# here e is a Graphs.SimpleEdge
 julia> for e in mes[1] 
            println(e)
        end

--- a/src/Multigraphs.jl
+++ b/src/Multigraphs.jl
@@ -1,7 +1,7 @@
 """
     Multigraphs
 
-An multigraph extension for `LightGraphs`.
+An multigraph extension for `Graphs`.
 """
 module Multigraphs
 

--- a/src/abstract_multigraph.jl
+++ b/src/abstract_multigraph.jl
@@ -1,8 +1,8 @@
-using LightGraphs
+using Graphs
 using SparseArrays
 
 import Base: show, eltype, copy
-import LightGraphs: nv, has_edge, has_vertex, add_edge!, rem_edge!, rem_vertex!,
+import Graphs: nv, has_edge, has_vertex, add_edge!, rem_edge!, rem_vertex!,
     rem_vertices!, add_vertex!, add_vertices!, outneighbors, inneighbors, vertices, edges,
     adjacency_matrix, src, dst, nv, edgetype
 
@@ -57,7 +57,7 @@ is not less than `mul`.
 
 ## Examples
 ```julia
-julia> using LightGraphs, Multigraphs
+julia> using Graphs, Multigraphs
 
 julia> mg = Multigraph(3);
 
@@ -82,7 +82,7 @@ Return `true` multiple edge was added successfully, otherwise return `false`.
 
 ## Examples
 ```julia
-julia> using LightGraphs, Multigraphs
+julia> using Graphs, Multigraphs
 
 julia> mg = Multigraph(3);
 
@@ -109,7 +109,7 @@ a multiple edge.
 
 ## Examples
 ```julia
-julia> using LightGraphs, Multigraphs
+julia> using Graphs, Multigraphs
 
 julia> mg = Multigraph(3);
 
@@ -139,7 +139,7 @@ Return a  `MultipleEdgeIter` for `mg`.
 ## Examples
 ```jltestdoc
 julia>
-julia> using LightGraphs, Multigraphs
+julia> using Graphs, Multigraphs
 
 julia> mg = Multigraph(path_graph(4));
 

--- a/src/di_multigraph_adjlist.jl
+++ b/src/di_multigraph_adjlist.jl
@@ -1,7 +1,7 @@
-using LightGraphs, SparseArrays, LinearAlgebra
+using Graphs, SparseArrays, LinearAlgebra
 
 import Base: copy
-import LightGraphs: nv, has_edge, add_edge!, rem_edge!, rem_vertex!,
+import Graphs: nv, has_edge, add_edge!, rem_edge!, rem_vertex!,
     rem_vertices!, add_vertex!, add_vertices!, outneighbors, inneighbors, neighbors,
     vertices, adjacency_matrix, ne, is_directed, degree, indegree, outdegree, edges,
     has_vertex, all_neighbors
@@ -53,7 +53,7 @@ function DiMultigraph(n::T) where {T<:Integer}
     end
     return DiMultigraph(adjlist)
 end
-DiMultigraph(g::SimpleDiGraph{T}) where {T<:Integer} = DiMultigraph(Dict(zip(T(1):nv(g), LightGraphs.SimpleGraphs.fadj(g))))
+DiMultigraph(g::SimpleDiGraph{T}) where {T<:Integer} = DiMultigraph(Dict(zip(T(1):nv(g), Graphs.SimpleGraphs.fadj(g))))
 
 copy(mg::DiMultigraph{T}) where {T} = DiMultigraph{T}(deepcopy(mg.adjlist), mg._idmax)
 

--- a/src/multigraph_adjlist.jl
+++ b/src/multigraph_adjlist.jl
@@ -1,7 +1,7 @@
-using LightGraphs, SparseArrays, LinearAlgebra
+using Graphs, SparseArrays, LinearAlgebra
 
 import Base: copy
-import LightGraphs: nv, has_edge, add_edge!, rem_edge!, rem_vertex!,
+import Graphs: nv, has_edge, add_edge!, rem_edge!, rem_vertex!,
     rem_vertices!, add_vertex!, add_vertices!, outneighbors, inneighbors, neighbors,
     vertices, adjacency_matrix, ne, is_directed, degree, indegree, outdegree, edges,
     has_vertex, all_neighbors
@@ -56,7 +56,7 @@ function Multigraph(n::T) where {T<:Integer}
     end
     return Multigraph(adjlist)
 end
-Multigraph(g::SimpleGraph{T}) where {T<:Integer} = Multigraph(Dict(zip(T(1):nv(g), LightGraphs.SimpleGraphs.fadj(g))))
+Multigraph(g::SimpleGraph{T}) where {T<:Integer} = Multigraph(Dict(zip(T(1):nv(g), Graphs.SimpleGraphs.fadj(g))))
 
 copy(mg::Multigraph{T}) where {T} = Multigraph{T}(deepcopy(mg.adjlist), mg._idmax)
 

--- a/src/multiple_edge.jl
+++ b/src/multiple_edge.jl
@@ -1,5 +1,5 @@
 import Base: eltype, Pair, Tuple, show, ==, iterate, length
-import LightGraphs: AbstractEdge, SimpleEdge, src, dst, reverse
+import Graphs: AbstractEdge, SimpleEdge, src, dst, reverse
 
 export AbstractMultipleEdge, MultipleEdge, mul
 
@@ -17,7 +17,7 @@ A struct representing multiple edges.
 
 ## Examples
 ```jltestdoc
-julia> using LightGraphs, Multigraphs
+julia> using Graphs, Multigraphs
 
 julia> me = MultipleEdge(1, 2, 3)
 Multiple edge 1 => 2 with multiplicity 3
@@ -67,7 +67,7 @@ Return the multiplicity of the multiple edge `e`.
 
 ## Examples
 ```jltestdoc
-julia> using LightGraphs, Multigraphs
+julia> using Graphs, Multigraphs
 
 julia> me = MultipleEdge(1, 2, 3)
 Multiple edge 1 => 2 with multiplicity 3

--- a/src/multiple_edge_iter.jl
+++ b/src/multiple_edge_iter.jl
@@ -1,4 +1,4 @@
-using LightGraphs
+using Graphs
 
 import Base: eltype, iterate, length
 

--- a/test/di_multigraph_adjlist.jl
+++ b/test/di_multigraph_adjlist.jl
@@ -1,4 +1,4 @@
-using Multigraphs, LightGraphs, SparseArrays
+using Multigraphs, Graphs, SparseArrays
 using Test
 try
     m2 = spzeros(Int, 2, 3)

--- a/test/multigraph_adjlist.jl
+++ b/test/multigraph_adjlist.jl
@@ -1,4 +1,4 @@
-using Multigraphs, LightGraphs, SparseArrays
+using Multigraphs, Graphs, SparseArrays
 try
     m2 = spzeros(Int, 2, 3)
     dg = Multigraph(m2)

--- a/test/multiple_edge.jl
+++ b/test/multiple_edge.jl
@@ -5,7 +5,7 @@ catch err
     @test err != nothing
 end
 @test src(me) == 1 && dst(me) == 2 && mul(me) == 3
-e0 = LightGraphs.SimpleEdge(me)
+e0 = Graphs.SimpleEdge(me)
 MultipleEdge(e0)
 @test MultipleEdge(1, 2) == e0
 @test e0 == MultipleEdge(1, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Multigraphs, LightGraphs, SparseArrays
+using Multigraphs, Graphs, SparseArrays
 using Test
 
 @testset "multiple_edge.jl" begin


### PR DESCRIPTION
Since `LightGraphs` has been archived, we need to change the deps to the new `Graphs` packege.