### PR TITLE
Add empty constructors

### DIFF
--- a/src/di_multigraph_adjlist.jl
+++ b/src/di_multigraph_adjlist.jl
@@ -45,6 +45,9 @@ function DiMultigraph(adjmx::AbstractMatrix{U}) where {U<:Integer}
     end
     DiMultigraph{Int}(adjlist, m)
 end
+DiMultigraph() = DiMultigraph(0)
+DiMultigraph{T}() where T = DiMultigraph(0)
+DiMultigraph{T}(t::T) where T = DiMultigraph(t)
 function DiMultigraph(n::T) where {T<:Integer} 
     n >= 0 || error("Number of vertices should be non-negative")
     adjlist = Dict{T, Vector{T}}()

--- a/src/multigraph_adjlist.jl
+++ b/src/multigraph_adjlist.jl
@@ -48,6 +48,9 @@ function Multigraph(adjmx::AbstractMatrix{U}) where {U<:Integer}
     end
     Multigraph{Int}(adjlist, m)
 end
+Multigraph() = Multigraph(0)
+Multigraph{T}() where T = Multigraph(0)
+Multigraph{T}(t::T) where T = Multigraph(t)
 function Multigraph(n::T) where {T<:Integer} 
     n >= 0 || error("Number of vertices should be non-negative")
     adjlist = Dict{T, Vector{T}}()

--- a/test/di_multigraph_adjlist.jl
+++ b/test/di_multigraph_adjlist.jl
@@ -73,3 +73,10 @@ add_vertex!(g)
 
 dmg0 = DiMultigraph(0)
 @test nv(dmg0) == ne(dmg0) == 0
+
+#test constructor
+@test try DiMultigraph(1); true; catch; false; end
+@test try DiMultigraph{Int}(1); true; catch; false; end
+@test try DiMultigraph(); true; catch; false; end
+@test try DiMultigraph{Int}(); true; catch; false; end
+

--- a/test/multigraph_adjlist.jl
+++ b/test/multigraph_adjlist.jl
@@ -69,3 +69,10 @@ add_vertex!(g)
 
 mg0 = Multigraph(0)
 @test nv(mg0) == ne(mg0) == 0
+
+#test constructor
+@test try Multigraph(1); true; catch; false; end
+@test try Multigraph{Int}(1); true; catch; false; end
+@test try Multigraph(); true; catch; false; end
+@test try Multigraph{Int}(); true; catch; false; end
+


### PR DESCRIPTION
Many graph implementations support empty constructors. e.g. SimpleGraph, MetaGraph..
Some of my code in NestedGraphs.jl uses this to initialize a graph. 
Due to this I couldn't construct a NestedGraph{MultiGraph} kind of structure.
With these minor changes, now it's possible.