### PR TITLE
Return correct type add_vertex! and add_vertices!

### DIFF
--- a/src/abstract_multigraph.jl
+++ b/src/abstract_multigraph.jl
@@ -126,7 +126,7 @@ rem_edge!(mg::AbstractMultigraph, x, y, z) = rem_edge!(mg, MultipleEdge(x, y, z)
 
 has_vertex(mg::AbstractMultigraph, v::Integer) = v in vertices(mg)
 rem_vertex!(mg::AbstractMultigraph{T}, v::T) where {T<:Integer} = rem_vertices!(mg, [v])
-add_vertex!(mg::AbstractMultigraph{T}) where {T<:Integer} = add_vertices!(mg, one(T))
+add_vertex!(mg::AbstractMultigraph{T}) where {T<:Integer} = add_vertices!(mg, one(T)) == 1 ? true : false
 
 function outneighbors(mg::AbstractMultigraph, v) end
 function inneighbors(mg::AbstractMultigraph, v) end

--- a/src/multigraph_adjlist.jl
+++ b/src/multigraph_adjlist.jl
@@ -131,7 +131,7 @@ function add_vertices!(mg::Multigraph{T}, n::Integer) where {T<:Integer}
     for i in new_ids
         mg.adjlist[i] = T[]
     end
-    return new_ids
+    return length(new_ids)
 end
 
 function outneighbors(mg::Multigraph, v::Integer; count_mul::Bool = false)

--- a/test/multigraph_adjlist.jl
+++ b/test/multigraph_adjlist.jl
@@ -69,3 +69,7 @@ add_vertex!(g)
 
 mg0 = Multigraph(0)
 @test nv(mg0) == ne(mg0) == 0
+# addvertex returns correct type
+@test add_vertex!(mg0)
+@test add_vertices!(mg0, 5) == 5
+


### PR DESCRIPTION
`add_vertex!` is supposed to return a `Bool` and `add_vertices!` an integer notating the number of vertices that were added.
Usually `add_vertices` uses iteratively `add_vertex`, but this package deals with this the other way around.
really, why do this ? The way it's done now, `add_vertices` doesn't also check for overflows. 

I stumbled into this problem because I tried playing with MetaGraphsNext.MetaGraph{Multigraph} and it hit an error here: https://github.com/JuliaGraphs/MetaGraphsNext.jl/blob/71cf31d8710fa419896af3ae03b9d4f943844402/src/graphs.jl#L117
