### PR TITLE
Allow construction of DiMultigraph{T} for T != Int64

### DIFF
--- a/src/di_multigraph_adjlist.jl
+++ b/src/di_multigraph_adjlist.jl
@@ -26,7 +26,7 @@ mutable struct DiMultigraph{T<:Integer} <: AbstractMultigraph{T}
     end
 end
 
-DiMultigraph(adjlist::Dict{T, Vector{T}}) where {T<:Integer} = DiMultigraph{T}(adjlist, isempty(adjlist) ? 0 : maximum(keys(adjlist)))
+DiMultigraph(adjlist::Dict{T, Vector{T}}) where {T<:Integer} = DiMultigraph{T}(adjlist, T(isempty(adjlist) ? 0 : maximum(keys(adjlist))))
 function DiMultigraph(adjmx::AbstractMatrix{U}) where {U<:Integer}
     m, n = size(adjmx)
     if m != n
@@ -45,7 +45,8 @@ function DiMultigraph(adjmx::AbstractMatrix{U}) where {U<:Integer}
     end
     DiMultigraph{Int}(adjlist, m)
 end
-function DiMultigraph(n::T) where {T<:Integer} 
+DiMultigraph{T}(n::Integer) where {T<:Integer} = DiMultigraph(T(n))
+function DiMultigraph(n::T) where {T<:Integer}
     n >= 0 || error("Number of vertices should be non-negative")
     adjlist = Dict{T, Vector{T}}()
     for i = 1:n
@@ -139,7 +140,7 @@ function outneighbors(mg::DiMultigraph, v::Integer; count_mul::Bool = false)
 end
 function inneighbors(mg::DiMultigraph{T}, v::Integer; count_mul::Bool = false) where T
     has_vertex(mg, v) || error("Vertex not found!")
-    
+
     innb = T[]
     for u in vertices(mg)
         mul_u_v = length(searchsorted(outneighbors(mg, u), v))

--- a/test/di_multigraph_adjlist.jl
+++ b/test/di_multigraph_adjlist.jl
@@ -73,3 +73,6 @@ add_vertex!(g)
 
 dmg0 = DiMultigraph(0)
 @test nv(dmg0) == ne(dmg0) == 0
+
+@test isa(DiMultigraph{Int32}(0), DiMultigraph{Int32})
+@test isa(DiMultigraph(Int32(0)), DiMultigraph{Int32})


### PR DESCRIPTION
The following throw a "no method" error:
```julia
DiMultigraph{Int32}(0)
DiMultigraph(Int32(0))
DiMultigraph{Int32}(Int32(0))
```
etc.

This PR makes the three calls above do what is expected.